### PR TITLE
Use graphqlSchema from pack dependency on eachType

### DIFF
--- a/src/mirage/wrappers/patch-auto-unions-interfaces.ts
+++ b/src/mirage/wrappers/patch-auto-unions-interfaces.ts
@@ -1,30 +1,28 @@
 import { eachType } from '../../resolver-map/each-type';
-import { GraphQLSchema, GraphQLInterfaceType, GraphQLUnionType } from 'graphql';
-import { ResolverMapWrapper, Resolver } from '../../types';
+import { GraphQLInterfaceType, GraphQLUnionType } from 'graphql';
+import { Resolver } from '../../types';
 import { mirageUnionResolver } from '../../mirage/resolvers/union';
 import { mirageInterfaceResolver } from '../../mirage/resolvers/interface';
 import { embedPackOptions } from '../../resolver-map/pack-wrapper';
 
-export const patchUnionsInterfaces = (schema: GraphQLSchema): ResolverMapWrapper => {
-  return eachType(schema, {
-    withType({ resolvers, type, packOptions }) {
-      let patchResolver: Resolver;
+export const patchUnionsInterfaces = eachType({
+  withType({ resolvers, type, packOptions }) {
+    let patchResolver: Resolver;
 
-      if (type instanceof GraphQLUnionType) {
-        patchResolver = mirageUnionResolver;
-      } else if (type instanceof GraphQLInterfaceType) {
-        patchResolver = mirageInterfaceResolver;
-      } else {
-        return;
-      }
+    if (type instanceof GraphQLUnionType) {
+      patchResolver = mirageUnionResolver;
+    } else if (type instanceof GraphQLInterfaceType) {
+      patchResolver = mirageInterfaceResolver;
+    } else {
+      return;
+    }
 
-      if (patchResolver) {
-        const alreadyHasResolveTypeResolver = resolvers[type.name]?.__resolveType;
-        if (!alreadyHasResolveTypeResolver) {
-          resolvers[type.name] = resolvers[type.name] || {};
-          resolvers[type.name].__resolveType = embedPackOptions(patchResolver, packOptions);
-        }
+    if (patchResolver) {
+      const alreadyHasResolveTypeResolver = resolvers[type.name]?.__resolveType;
+      if (!alreadyHasResolveTypeResolver) {
+        resolvers[type.name] = resolvers[type.name] || {};
+        resolvers[type.name].__resolveType = embedPackOptions(patchResolver, packOptions);
       }
-    },
-  });
-};
+    }
+  },
+});

--- a/src/resolver-map/each-type.ts
+++ b/src/resolver-map/each-type.ts
@@ -1,4 +1,4 @@
-import { GraphQLSchema, GraphQLType } from 'graphql';
+import { GraphQLType, GraphQLSchema } from 'graphql';
 import { ResolverMapWrapper, ResolverMap, PackOptions } from '../types';
 
 type WithType = {
@@ -11,11 +11,12 @@ type PatchOptions = {
   withType({ type, resolvers, packOptions }: WithType): void;
 };
 
-export const eachType = (schema: GraphQLSchema, options: PatchOptions): ResolverMapWrapper => (
+export const eachType = (options: PatchOptions): ResolverMapWrapper => (
   resolvers: ResolverMap,
   packOptions: PackOptions,
 ) => {
-  const typeMap = schema.getTypeMap();
+  const { graphqlSchema: schema } = packOptions.dependencies;
+  const typeMap = (schema as GraphQLSchema).getTypeMap();
 
   for (const type of Object.values(typeMap)) {
     options.withType({ type, resolvers, packOptions });

--- a/tests/integration/mirage-auto-resolver.test.ts
+++ b/tests/integration/mirage-auto-resolver.test.ts
@@ -24,7 +24,7 @@ describe('auto resolving from mirage', function() {
       .add(['Person', 'fullName'], ['Person', 'name']);
 
     mirageServer.db.loadData(defaultScenario);
-    const wrappers = [patchWithAutoTypesWrapper, patchUnionsInterfaces(schema)];
+    const wrappers = [patchWithAutoTypesWrapper, patchUnionsInterfaces];
     const packed = pack(defaultResolvers, wrappers, {
       dependencies: {
         mapper,

--- a/tests/unit/mirage/wrappers/patch-auto-unions-interfaces.test.ts
+++ b/tests/unit/mirage/wrappers/patch-auto-unions-interfaces.test.ts
@@ -43,8 +43,10 @@ describe('mirage/wrappers/patch-auto-unions-interfaces', function() {
     expect(resolverMap?.Salutation?.__resolveType).to.not.exist;
     expect(resolverMap?.Animal?.__resolveType).to.not.exist;
 
-    const wrapper = patchUnionsInterfaces(schema!);
-    const wrappedResolvers = wrapper(resolverMap!, generatePackOptions());
+    const wrappedResolvers = patchUnionsInterfaces(
+      resolverMap!,
+      generatePackOptions({ dependencies: { graphqlSchema: schema } }),
+    );
 
     expect(wrappedResolvers?.Salutation?.__resolveType).to.exist;
     expect(wrappedResolvers?.Animal?.__resolveType).to.exist;
@@ -62,8 +64,10 @@ describe('mirage/wrappers/patch-auto-unions-interfaces', function() {
       },
     };
 
-    const wrapper = patchUnionsInterfaces(schema!);
-    const wrappedResolvers = wrapper(resolverMap!, generatePackOptions());
+    const wrappedResolvers = patchUnionsInterfaces(
+      resolverMap!,
+      generatePackOptions({ dependencies: { graphqlSchema: schema } }),
+    );
     expect(wrappedResolvers).to.deep.equal(resolverMap);
   });
 });

--- a/tests/unit/resolver-map/each-type.test.ts
+++ b/tests/unit/resolver-map/each-type.test.ts
@@ -34,9 +34,9 @@ describe('resolver-map/each-type', function() {
     const withTypeSpy = sinon.spy();
     const resolverMap = {};
 
-    eachType(schema, {
+    eachType({
       withType: withTypeSpy,
-    })(resolverMap, generatePackOptions());
+    })(resolverMap, generatePackOptions({ dependencies: { graphqlSchema: schema } }));
 
     const typesCalled = withTypeSpy.getCalls().map(call => call.args[0].type.name);
 


### PR DESCRIPTION
Anything that is a widespread dependency should be passed into the pack dependencies. This PR fixes a leftover graphql schema dependency on `eachType` that can use the `graphqlSchema` conventional dependency that other wrappers depend on, too. 