### PR TITLE
Add resolver field wrappers

### DIFF
--- a/src/log/wrapper.ts
+++ b/src/log/wrapper.ts
@@ -1,7 +1,6 @@
-import { wrapEachField } from '../resolver-map/wrap-each-field';
-import { ResolverMapWrapper, ResolverWrapper } from '../types';
+import { ResolverWrapper } from '../types';
 
-export const logSingular: ResolverWrapper = (originalResolver, wrapperDetails) => {
+export const logWrapper: ResolverWrapper = (originalResolver, wrapperDetails) => {
   const { type, field } = wrapperDetails;
   const typeName = type.name;
   const fieldName = field.name;
@@ -18,5 +17,3 @@ export const logSingular: ResolverWrapper = (originalResolver, wrapperDetails) =
     return result;
   };
 };
-
-export const logWrapper: ResolverMapWrapper = wrapEachField([logSingular]);

--- a/src/log/wrapper.ts
+++ b/src/log/wrapper.ts
@@ -2,10 +2,12 @@ import { wrapEachField } from '../resolver-map/wrap-each-field';
 import { ResolverMapWrapper } from '../types';
 
 export const logWrapper: ResolverMapWrapper = wrapEachField((originalResolver, wrapperDetails) => {
-  const [type, field] = wrapperDetails.path;
+  const { type, field } = wrapperDetails;
+  const typeName = type.name;
+  const fieldName = field.name;
 
   return async (parent, args, context, info) => {
-    console.log(`Resolver for type: "${type}" field: "${field}"`);
+    console.log(`Resolver for type: "${typeName}" field: "${fieldName}"`);
     console.log(`parent: ${JSON.stringify(parent)}`);
     console.log(`args: ${JSON.stringify(args)}`);
     console.log(`context: ${JSON.stringify(context)}`);

--- a/src/log/wrapper.ts
+++ b/src/log/wrapper.ts
@@ -1,7 +1,7 @@
 import { wrapEachField } from '../resolver-map/wrap-each-field';
-import { ResolverMapWrapper } from '../types';
+import { ResolverMapWrapper, ResolverWrapper } from '../types';
 
-export const logWrapper: ResolverMapWrapper = wrapEachField((originalResolver, wrapperDetails) => {
+export const logSingular: ResolverWrapper = (originalResolver, wrapperDetails) => {
   const { type, field } = wrapperDetails;
   const typeName = type.name;
   const fieldName = field.name;
@@ -17,4 +17,6 @@ export const logWrapper: ResolverMapWrapper = wrapEachField((originalResolver, w
 
     return result;
   };
-});
+};
+
+export const logWrapper: ResolverMapWrapper = wrapEachField([logSingular]);

--- a/src/mirage/wrappers/patch-auto-types.ts
+++ b/src/mirage/wrappers/patch-auto-types.ts
@@ -2,13 +2,18 @@ import { mirageObjectResolver } from '../resolvers/object';
 import { mirageRelayResolver } from '../resolvers/relay';
 import { patchEachField } from '../../resolver-map/patch-each-field';
 import { unwrap } from '../../utils';
+import { GraphQLObjectType, GraphQLField } from 'graphql';
 
 export const patchWithAutoTypesWrapper = patchEachField(({ type, field }) => {
   const isRootQueryType = type.name === 'Query';
   const isRootMutationType = type.name === 'Mutation';
   const isGraphQLInternalType = type.name.indexOf('__') === 0;
 
-  const unwrappedReturnType = unwrap(field.type);
+  if (!(type instanceof GraphQLObjectType)) {
+    throw new TypeError('field must be an instanceof GraphQLField for patching');
+  }
+
+  const unwrappedReturnType = unwrap((field as GraphQLField<any, any>).type);
 
   if ('name' in unwrappedReturnType && unwrappedReturnType.name.endsWith('Connection')) {
     return mirageRelayResolver;

--- a/src/mirage/wrappers/patch-auto-unions-interfaces.ts
+++ b/src/mirage/wrappers/patch-auto-unions-interfaces.ts
@@ -1,4 +1,4 @@
-import { GraphQLInterfaceType, GraphQLUnionType, GraphQLSchema } from 'graphql';
+import { GraphQLInterfaceType, GraphQLUnionType, GraphQLSchema, GraphQLObjectType, GraphQLField } from 'graphql';
 import { Resolver, PackOptions, ResolverMap } from '../../types';
 import { mirageUnionResolver } from '../../mirage/resolvers/union';
 import { mirageInterfaceResolver } from '../../mirage/resolvers/interface';
@@ -27,7 +27,13 @@ export function patchUnionsInterfaces(resolvers: ResolverMap, packOptions: PackO
 
     if (typeof patchResolver === 'function') {
       resolvers[type.name] = resolvers[type.name] || {};
-      resolvers[type.name].__resolveType = embedPackOptions(patchResolver, packOptions);
+
+      resolvers[type.name].__resolveType = embedPackOptions(patchResolver, {
+        type,
+        field: { name: '__resolveType' },
+        resolvers,
+        packOptions,
+      });
     }
   }
 

--- a/src/performance/wrapper.ts
+++ b/src/performance/wrapper.ts
@@ -2,11 +2,14 @@ import { wrapEachField } from '../resolver-map/wrap-each-field';
 import { ResolverMapWrapper } from '../types';
 
 export const performanceWrapper: ResolverMapWrapper = wrapEachField((originalResolver, wrapperDetails) => {
-  const [type, field] = wrapperDetails.path;
+  const { type, field } = wrapperDetails;
+  const typeName = type.name;
+  const fieldName = field.name;
+
   const packState = wrapperDetails.packOptions.state;
   packState.performance = packState.performance = {};
-  packState.performance[type] = packState.performance[type] || {};
-  packState.performance[type][field] = packState.performance[type][field] || [];
+  packState.performance[typeName] = packState.performance[typeName] || {};
+  packState.performance[typeName][fieldName] = packState.performance[typeName][fieldName] || [];
 
   return async (parent, args, context, info) => {
     const start = Date.now();
@@ -14,7 +17,7 @@ export const performanceWrapper: ResolverMapWrapper = wrapEachField((originalRes
     const end = Date.now();
     const difference = end - start;
 
-    packState.performance[type][field].push(difference);
+    packState.performance[typeName][fieldName].push(difference);
 
     return result;
   };

--- a/src/performance/wrapper.ts
+++ b/src/performance/wrapper.ts
@@ -1,7 +1,6 @@
-import { wrapEachField } from '../resolver-map/wrap-each-field';
-import { ResolverMapWrapper, ResolverWrapper } from '../types';
+import { ResolverWrapper } from '../types';
 
-export const performanceSingular: ResolverWrapper = (originalResolver, wrapperDetails) => {
+export const performanceWrapper: ResolverWrapper = (originalResolver, wrapperDetails) => {
   const { type, field } = wrapperDetails;
   const typeName = type.name;
   const fieldName = field.name;
@@ -22,5 +21,3 @@ export const performanceSingular: ResolverWrapper = (originalResolver, wrapperDe
     return result;
   };
 };
-
-export const performanceWrapper: ResolverMapWrapper = wrapEachField([performanceSingular]);

--- a/src/performance/wrapper.ts
+++ b/src/performance/wrapper.ts
@@ -1,7 +1,7 @@
 import { wrapEachField } from '../resolver-map/wrap-each-field';
-import { ResolverMapWrapper } from '../types';
+import { ResolverMapWrapper, ResolverWrapper } from '../types';
 
-export const performanceWrapper: ResolverMapWrapper = wrapEachField((originalResolver, wrapperDetails) => {
+export const performanceSingular: ResolverWrapper = (originalResolver, wrapperDetails) => {
   const { type, field } = wrapperDetails;
   const typeName = type.name;
   const fieldName = field.name;
@@ -21,4 +21,6 @@ export const performanceWrapper: ResolverMapWrapper = wrapEachField((originalRes
 
     return result;
   };
-});
+};
+
+export const performanceWrapper: ResolverMapWrapper = wrapEachField([performanceSingular]);

--- a/src/resolver-map/pack.ts
+++ b/src/resolver-map/pack.ts
@@ -5,12 +5,8 @@ import { embedPackOptions } from '../utils';
 
 const defaultPackOptions: PackOptions = { state: {}, dependencies: {} };
 
-export const packWrapper = wrapEachField((resolver, { packOptions }) => {
-  return embedPackOptions(resolver, packOptions);
-});
-
 export const pack: Packer = (initialResolversMap, wrappers, packOptions = defaultPackOptions) => {
-  wrappers = [packWrapper, ...wrappers];
+  wrappers = [...wrappers, wrapEachField([embedPackOptions])];
 
   // make an intial copy
   let wrappedMap = cloneDeep(initialResolversMap);

--- a/src/resolver-map/patch-each-field.ts
+++ b/src/resolver-map/patch-each-field.ts
@@ -1,10 +1,8 @@
 import { GraphQLObjectType } from 'graphql';
-import { Resolver, ResolverMap, ResolverMapWrapper, EachFieldContext } from '../types';
+import { ResolverMap, ResolverMapWrapper, PatchResolverWrapper } from '../types';
 import { embedPackOptions } from '../utils';
 
-export type PatchEachFieldWrapper = (eachFieldContext: EachFieldContext) => Resolver | undefined;
-
-export const patchEachField = (patchWith: PatchEachFieldWrapper): ResolverMapWrapper => (
+export const patchEachField = (patchWith: PatchResolverWrapper): ResolverMapWrapper => (
   resolvers: ResolverMap,
   packOptions,
 ) => {

--- a/src/resolver-map/patch-each-field.ts
+++ b/src/resolver-map/patch-each-field.ts
@@ -1,4 +1,4 @@
-import { GraphQLObjectType, GraphQLField } from 'graphql';
+import { GraphQLObjectType } from 'graphql';
 import { Resolver, ResolverMap, ResolverMapWrapper, EachFieldContext } from '../types';
 import { embedPackOptions } from '../utils';
 
@@ -23,13 +23,10 @@ export const patchEachField = (patchWith: PatchEachFieldWrapper): ResolverMapWra
         const field = fields[fieldKey];
 
         if (!resolvers[typeKey] || (resolvers[typeKey] && !resolvers[typeKey][fieldKey])) {
-          const path: [string, string] = [(type as GraphQLObjectType).name, (field as GraphQLField<any, any>).name];
-
           const patchResolver = patchWith({
             resolvers,
             type: type as GraphQLObjectType,
             field,
-            path,
             packOptions,
           });
 

--- a/src/resolver-map/wrap-each-field.ts
+++ b/src/resolver-map/wrap-each-field.ts
@@ -1,10 +1,8 @@
-import { Resolver, ResolverMap, ResolverMapWrapper, PackOptions, EachFieldContext } from '../types';
-import { embedPackOptions } from '../utils';
 import { GraphQLObjectType, GraphQLSchema, GraphQLFieldMap } from 'graphql';
+import { ResolverMap, ResolverMapWrapper, PackOptions, ResolverWrapper } from '../types';
+import { embedPackOptions } from '../utils';
 
-type WrapEachFieldWrapper = (resolver: Resolver, eachFieldContext: EachFieldContext) => Resolver | undefined;
-
-export const wrapEachField = (wrapWith: WrapEachFieldWrapper): ResolverMapWrapper => (
+export const wrapEachField = (wrapWith: ResolverWrapper): ResolverMapWrapper => (
   resolvers: ResolverMap,
   packOptions: PackOptions,
 ) => {

--- a/src/resolver-map/wrap-each-field.ts
+++ b/src/resolver-map/wrap-each-field.ts
@@ -10,7 +10,6 @@ export const wrapEachField = (wrapWith: WrapEachFieldWrapper): ResolverMapWrappe
 ) => {
   const { graphqlSchema: schema } = packOptions.dependencies;
   if (!schema) {
-    debugger;
     throw new Error('Include in your pack dependencies, key: "graphqlSchema" with an instance of your GraphQLSchema');
   }
 
@@ -35,7 +34,6 @@ export const wrapEachField = (wrapWith: WrapEachFieldWrapper): ResolverMapWrappe
         resolvers,
         type,
         field,
-        path: [typeName, fieldName],
         packOptions,
       });
 

--- a/src/resolver-map/wrap-each-field.ts
+++ b/src/resolver-map/wrap-each-field.ts
@@ -1,8 +1,8 @@
-import { GraphQLObjectType, GraphQLSchema, GraphQLFieldMap } from 'graphql';
 import { ResolverMap, ResolverMapWrapper, PackOptions, ResolverWrapper } from '../types';
-import { embedPackOptions } from '../utils';
+import { getTypeAndField, addResolverToMap, embedPackOptions } from '../utils';
+import { wrapResolver } from '../resolver/wrap';
 
-export const wrapEachField = (wrapWith: ResolverWrapper): ResolverMapWrapper => (
+export const wrapEachField = (resolverWrappers: ResolverWrapper[]): ResolverMapWrapper => (
   resolvers: ResolverMap,
   packOptions: PackOptions,
 ) => {
@@ -13,35 +13,23 @@ export const wrapEachField = (wrapWith: ResolverWrapper): ResolverMapWrapper => 
 
   for (const typeName in resolvers) {
     for (const fieldName in resolvers[typeName]) {
-      const resolver = resolvers[typeName][fieldName];
+      const resolverToWrap = resolvers[typeName][fieldName];
+      const [type, field] = getTypeAndField(typeName, fieldName, schema);
 
-      const type = (schema as GraphQLSchema).getType(typeName) as GraphQLObjectType;
-
-      if (!type) {
-        throw new Error(`Could not find a type ${typeName} on schema in wrapEach`);
-      }
-
-      const typeFields = type && 'getFields' in type && (type.getFields() as GraphQLFieldMap<any, any>);
-      const field = (typeFields && typeFields[fieldName]) || undefined;
-
-      if (!field) {
-        throw new Error(`Could not find a field ${fieldName} for type ${typeName} in wrapEach`);
-      }
-
-      const newResolver = wrapWith(resolver, {
-        resolvers,
+      const wrappedResolver = wrapResolver(resolverToWrap, [...resolverWrappers, embedPackOptions], {
         type,
         field,
+        resolvers,
         packOptions,
       });
 
-      if (typeof newResolver !== 'function') {
-        throw new Error(
-          `${wrapEachField.toString()} must return a function for resolver type: ${typeName}, field: ${fieldName}`,
-        );
-      }
-
-      resolvers[typeName][fieldName] = embedPackOptions(newResolver, packOptions);
+      addResolverToMap({
+        resolverMap: resolvers,
+        typeName,
+        fieldName,
+        resolver: wrappedResolver,
+        overwrite: true,
+      });
     }
   }
 

--- a/src/resolver/wrap-in-map.ts
+++ b/src/resolver/wrap-in-map.ts
@@ -1,4 +1,5 @@
 import cloneDeep from 'lodash.clonedeep';
+import { wrapResolver } from './wrap';
 import { Resolver, ResolverWrapper, ResolverMapWrapper } from '../types';
 import { getTypeAndField, addResolverToMap } from '../utils';
 

--- a/src/resolver/wrap-in-map.ts
+++ b/src/resolver/wrap-in-map.ts
@@ -1,0 +1,44 @@
+import cloneDeep from 'lodash.clonedeep';
+import { Resolver, ResolverWrapper, ResolverMapWrapper } from '../types';
+import { getTypeAndField, addResolverToMap } from '../utils';
+
+export function wrapResolverInMap(
+  typeName: string,
+  fieldName: string,
+  resolverWrappers: ResolverWrapper[],
+  resolver?: Resolver,
+): ResolverMapWrapper {
+  return (resolverMap, packOptions) => {
+    const schema = packOptions.dependencies.graphqlSchema;
+    if (!schema) {
+      throw new Error(
+        `"graphqlSchema" expected on packOptions.dependencies. Specify it on the dependencies of the \`pack\``,
+      );
+    }
+
+    resolver = resolver || resolverMap[typeName]?.[fieldName];
+    if (!resolver)
+      throw new Error(
+        `Could not determine resolver to wrap, either pass one into this \`wrap\`, or have an initial resolver on the resolver map at type: "${typeName}", field "${fieldName}"`,
+      );
+
+    const [type, field] = getTypeAndField(typeName, fieldName, schema);
+    const clonedWrappers = cloneDeep(resolverWrappers);
+    const wrappedResolver = wrapResolver(resolver, clonedWrappers, {
+      type,
+      field,
+      resolvers: resolverMap,
+      packOptions,
+    });
+
+    addResolverToMap({
+      resolverMap,
+      typeName,
+      fieldName,
+      resolver: wrappedResolver,
+      overwrite: true,
+    });
+
+    return resolverMap;
+  };
+}

--- a/src/resolver/wrap-in-map.ts
+++ b/src/resolver/wrap-in-map.ts
@@ -1,7 +1,6 @@
-import cloneDeep from 'lodash.clonedeep';
 import { wrapResolver } from './wrap';
 import { Resolver, ResolverWrapper, ResolverMapWrapper } from '../types';
-import { getTypeAndField, addResolverToMap } from '../utils';
+import { getTypeAndField, addResolverToMap, embedPackOptions } from '../utils';
 
 export function wrapResolverInMap(
   typeName: string,
@@ -18,14 +17,15 @@ export function wrapResolverInMap(
     }
 
     resolver = resolver || resolverMap[typeName]?.[fieldName];
-    if (!resolver)
+    if (!resolver) {
       throw new Error(
         `Could not determine resolver to wrap, either pass one into this \`wrap\`, or have an initial resolver on the resolver map at type: "${typeName}", field "${fieldName}"`,
       );
+    }
 
+    resolverWrappers = [...resolverWrappers, embedPackOptions];
     const [type, field] = getTypeAndField(typeName, fieldName, schema);
-    const clonedWrappers = cloneDeep(resolverWrappers);
-    const wrappedResolver = wrapResolver(resolver, clonedWrappers, {
+    const wrappedResolver = wrapResolver(resolver, resolverWrappers, {
       type,
       field,
       resolvers: resolverMap,

--- a/src/resolver/wrap.ts
+++ b/src/resolver/wrap.ts
@@ -5,11 +5,19 @@ export const wrapResolver = (
   wrappers: ResolverWrapper[],
   wrapperOptions: ResolverWrapperOptions,
 ): Resolver => {
+  wrappers = [...wrappers];
   const wrapper = wrappers.shift();
 
   if (!wrapper) {
     return resolver;
   }
 
-  return wrapResolver(wrapper(resolver, wrapperOptions), wrappers, wrapperOptions);
+  const wrappedResolver = wrapper(resolver, wrapperOptions);
+  if (typeof wrappedResolver !== 'function') {
+    throw new Error(
+      `Wrapper: ${wrapper.toString()}\n\nThis wrapper did not return a function, got ${typeof wrappedResolver}.`,
+    );
+  }
+
+  return wrapResolver(wrappedResolver, wrappers, wrapperOptions);
 };

--- a/src/resolver/wrap.ts
+++ b/src/resolver/wrap.ts
@@ -1,0 +1,15 @@
+import { Resolver, ResolverWrapper, ResolverWrapperOptions } from '../types';
+
+export const wrapResolver = (
+  resolver: Resolver,
+  wrappers: ResolverWrapper[],
+  wrapperOptions: ResolverWrapperOptions,
+): Resolver => {
+  const wrapper = wrappers.shift();
+
+  if (!wrapper) {
+    return resolver;
+  }
+
+  return wrapResolver(wrapper(resolver, wrapperOptions), wrappers, wrapperOptions);
+};

--- a/src/spy/wrapper.ts
+++ b/src/spy/wrapper.ts
@@ -1,8 +1,7 @@
 import { spy } from 'sinon';
-import { wrapEachField } from '../resolver-map/wrap-each-field';
-import { ResolverMapWrapper, ResolverWrapper } from '../types';
+import { ResolverWrapper } from '../types';
 
-export const spyWrapperSingular: ResolverWrapper = (originalResolver, wrapperDetails) => {
+export const spyWrapper: ResolverWrapper = (originalResolver, wrapperDetails) => {
   const { type, field } = wrapperDetails;
   const typeName = type.name;
   const fieldName = field.name;
@@ -15,5 +14,3 @@ export const spyWrapperSingular: ResolverWrapper = (originalResolver, wrapperDet
 
   return resolverSpy;
 };
-
-export const spyWrapper: ResolverMapWrapper = wrapEachField([spyWrapperSingular]);

--- a/src/spy/wrapper.ts
+++ b/src/spy/wrapper.ts
@@ -1,8 +1,8 @@
 import { spy } from 'sinon';
 import { wrapEachField } from '../resolver-map/wrap-each-field';
-import { ResolverMapWrapper } from '../types';
+import { ResolverMapWrapper, ResolverWrapper } from '../types';
 
-export const spyWrapper: ResolverMapWrapper = wrapEachField((originalResolver, wrapperDetails) => {
+export const spyWrapperSingular: ResolverWrapper = (originalResolver, wrapperDetails) => {
   const { type, field } = wrapperDetails;
   const typeName = type.name;
   const fieldName = field.name;
@@ -14,4 +14,6 @@ export const spyWrapper: ResolverMapWrapper = wrapEachField((originalResolver, w
   packState.spies[typeName][fieldName] = resolverSpy;
 
   return resolverSpy;
-});
+};
+
+export const spyWrapper: ResolverMapWrapper = wrapEachField([spyWrapperSingular]);

--- a/src/spy/wrapper.ts
+++ b/src/spy/wrapper.ts
@@ -3,13 +3,15 @@ import { wrapEachField } from '../resolver-map/wrap-each-field';
 import { ResolverMapWrapper } from '../types';
 
 export const spyWrapper: ResolverMapWrapper = wrapEachField((originalResolver, wrapperDetails) => {
-  const [type, field] = wrapperDetails.path;
+  const { type, field } = wrapperDetails;
+  const typeName = type.name;
+  const fieldName = field.name;
   const packState = wrapperDetails.packOptions.state;
   const resolverSpy = spy(originalResolver);
 
   packState.spies = packState.spies = {};
-  packState.spies[type] = packState.spies[type] || {};
-  packState.spies[type][field] = resolverSpy;
+  packState.spies[typeName] = packState.spies[typeName] || {};
+  packState.spies[typeName][fieldName] = resolverSpy;
 
   return resolverSpy;
 });

--- a/src/stash-state/wrapper.ts
+++ b/src/stash-state/wrapper.ts
@@ -1,5 +1,5 @@
 import { wrapEachField } from '../resolver-map/wrap-each-field';
-import { ResolverMapWrapper } from '../types';
+import { ResolverMapWrapper, ResolverWrapper } from '../types';
 
 type ResolverStash = {
   parent: any;
@@ -14,7 +14,7 @@ export const stashFor = (ref: any): ResolverStash | undefined => {
   return ref && ref[stashKey];
 };
 
-export const stashStateWrapper: ResolverMapWrapper = wrapEachField((originalResolver) => {
+export const stashStateSingular: ResolverWrapper = (originalResolver) => {
   return (parent, args, context, info) => {
     const result = originalResolver(parent, args, context, info);
 
@@ -32,4 +32,6 @@ export const stashStateWrapper: ResolverMapWrapper = wrapEachField((originalReso
 
     return result;
   };
-});
+};
+
+export const stashStateWrapper: ResolverMapWrapper = wrapEachField([stashStateSingular]);

--- a/src/stash-state/wrapper.ts
+++ b/src/stash-state/wrapper.ts
@@ -1,5 +1,4 @@
-import { wrapEachField } from '../resolver-map/wrap-each-field';
-import { ResolverMapWrapper, ResolverWrapper } from '../types';
+import { ResolverWrapper } from '../types';
 
 type ResolverStash = {
   parent: any;
@@ -14,7 +13,7 @@ export const stashFor = (ref: any): ResolverStash | undefined => {
   return ref && ref[stashKey];
 };
 
-export const stashStateSingular: ResolverWrapper = (originalResolver) => {
+export const stashStateWrapper: ResolverWrapper = (originalResolver) => {
   return (parent, args, context, info) => {
     const result = originalResolver(parent, args, context, info);
 
@@ -33,5 +32,3 @@ export const stashStateSingular: ResolverWrapper = (originalResolver) => {
     return result;
   };
 };
-
-export const stashStateWrapper: ResolverMapWrapper = wrapEachField([stashStateSingular]);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,16 @@
 import { GraphQLObjectType, GraphQLField } from 'graphql';
 
 export type Resolver = (parent: any, args: any, context: any, info: any) => any | Promise<any>;
+export type ResolverWrapper = (resolver: Resolver, options: ResolverWrapperOptions) => Resolver;
+
+export type PatchResolverWrapper = (options: ResolverWrapperOptions) => Resolver | undefined;
+
+export type ResolverWrapperOptions = {
+  resolvers: ResolverMap;
+  type: GraphQLObjectType;
+  field: GraphQLField<any, any, any>;
+  packOptions: PackOptions;
+};
 
 export type ResolverMap = {
   [type: string]: {
@@ -13,13 +23,6 @@ export type PackState = Record<any, any>;
 export type PackOptions = {
   state: PackState;
   dependencies: Record<string, any>;
-};
-
-export type EachFieldContext = {
-  resolvers: ResolverMap;
-  type: GraphQLObjectType;
-  field: GraphQLField<any, any, any>;
-  packOptions: PackOptions;
 };
 
 export type ResolverMapWrapper = (map: ResolverMap, packOptions: PackOptions) => ResolverMap;

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,7 +19,6 @@ export type EachFieldContext = {
   resolvers: ResolverMap;
   type: GraphQLObjectType;
   field: GraphQLField<any, any, any>;
-  path: [string, string];
   packOptions: PackOptions;
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,14 +1,25 @@
-import { GraphQLObjectType, GraphQLField } from 'graphql';
+import { GraphQLObjectType, GraphQLField, GraphQLUnionType, GraphQLInterfaceType } from 'graphql';
 
 export type Resolver = (parent: any, args: any, context: any, info: any) => any | Promise<any>;
 export type ResolverWrapper = (resolver: Resolver, options: ResolverWrapperOptions) => Resolver;
 
 export type PatchResolverWrapper = (options: ResolverWrapperOptions) => Resolver | undefined;
 
+// this exists on ResolverMap and is used for specifying a resolveType resolver
+// for graphql interfaces and unions, but is not a "real" field.
+export type AnonymousResolveTypeField = { name: '__resolveType'; [key: string]: '__resolveType' };
+
+// A resolvable type is a type that has a "field" that can be resolved by a resolver function
+export type ResolvableType = GraphQLObjectType | GraphQLUnionType | GraphQLInterfaceType;
+
+// A resolver function can either be a GraphQLField on a GraphQLObjectType
+// or an AnonymousResolveType resolver that is specifed by __resolveType
+export type ResolvableField = GraphQLField<any, any, any> | AnonymousResolveTypeField;
+
 export type ResolverWrapperOptions = {
   resolvers: ResolverMap;
-  type: GraphQLObjectType;
-  field: GraphQLField<any, any, any>;
+  type: ResolvableType;
+  field: ResolvableField;
   packOptions: PackOptions;
 };
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
-import { Resolver, PackOptions } from './types';
+import { Resolver, PackOptions, ResolverMap } from './types';
+import { GraphQLSchema, GraphQLField, GraphQLType, GraphQLObjectType } from 'graphql';
 
 export const unwrap = (type: any): any => (type?.ofType ? unwrap(type.ofType) : type);
 
@@ -15,3 +16,47 @@ export const embedPackOptions = (resolver: Resolver, packOptions: PackOptions) =
     return resolver(parent, args, context, info);
   };
 };
+
+export function getTypeAndField(
+  typeName: string,
+  fieldName: string,
+  schema: GraphQLSchema,
+): [GraphQLObjectType, GraphQLField<any, any, any>] {
+  const type = schema.getType(typeName);
+  if (!type) throw new Error(`Unable to find type "${typeName}" from from schema`);
+  if (!(type instanceof GraphQLObjectType)) throw new Error(`Type "${typeName}" must be an a GraphQLObjectType`);
+
+  const fields = type.getFields();
+  const field = fields[fieldName];
+
+  if (!field) throw new Error(`Field "${fieldName}" does not exist on type "${typeName}"`);
+
+  return [type, field];
+}
+
+export function addResolverToMap({
+  resolverMap,
+  typeName,
+  fieldName,
+  resolver,
+  overwrite = false,
+}: {
+  resolverMap: ResolverMap;
+  typeName: string;
+  fieldName: string;
+  resolver: Resolver;
+  overwrite?: boolean;
+}): ResolverMap {
+  if (typeof resolverMap !== 'object') throw new TypeError('resolverMap must be an object');
+
+  resolverMap[typeName] = resolverMap[typeName] ?? {};
+
+  if (resolverMap[typeName][fieldName] && !overwrite) {
+    throw new Error(
+      `The resolverMap already has a field specified at ${fieldName}, and the overwrite option was not set to true`,
+    );
+  }
+
+  resolverMap[typeName][fieldName] = resolver;
+  return resolverMap;
+}

--- a/tests/mocks.ts
+++ b/tests/mocks.ts
@@ -1,3 +1,4 @@
+import { buildSchema, GraphQLObjectType } from 'graphql';
 import { PackOptions } from '../src/types';
 
 export const generatePackOptions: (mixin?: Record<any, any>) => PackOptions = (mixin = {}) => {
@@ -7,3 +8,23 @@ export const generatePackOptions: (mixin?: Record<any, any>) => PackOptions = (m
     dependencies: { ...mixin.dependencies },
   };
 };
+
+export const schema = buildSchema(`
+  schema {
+    query: Query
+  }
+
+  type Query {
+    greeting: String!
+    user: User!
+  }
+
+  type User {
+    name: String!
+  }
+`);
+
+// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+export const userObjectType = schema.getType('User')! as GraphQLObjectType;
+export const userObjectFields = (userObjectType as GraphQLObjectType).getFields();
+export const userObjectNameField = userObjectFields['name'];

--- a/tests/unit/log/wrapper.test.ts
+++ b/tests/unit/log/wrapper.test.ts
@@ -1,11 +1,8 @@
-import { buildSchema } from 'graphql';
 import { logWrapper } from '../../../src/log/wrapper';
-import { pack } from '../../../src/resolver-map/pack';
-import { ResolverMap } from '../../../src/types';
+import { ResolverMap, Resolver } from '../../../src/types';
 import { expect } from 'chai';
 import { stub, SinonStub } from 'sinon';
-import { generatePackOptions } from '../../mocks';
-import { wrapEachField } from '../../../src/resolver-map/wrap-each-field';
+import { generatePackOptions, userObjectType, userObjectNameField } from '../../mocks';
 
 describe('log/wrapper', function () {
   let logStub: SinonStub;
@@ -19,35 +16,22 @@ describe('log/wrapper', function () {
   });
 
   it('logs details around calling resolvers', async function () {
-    const schema = buildSchema(`type Query { rootQueryField: String!}`);
-    const resolverMap: ResolverMap = {
-      Query: {
-        // eslint-disable-next-line
-        rootQueryField: async () => {
-          return {};
-        },
-      },
-    };
-
-    const { resolvers: wrappedResolvers } = pack(resolverMap, [wrapEachField([logWrapper])], {
-      dependencies: { graphqlSchema: schema },
+    const initialResolver = (() => ({})) as Resolver;
+    const wrappedResolver = logWrapper(initialResolver, {
+      resolvers: {} as ResolverMap,
+      type: userObjectType,
+      field: userObjectNameField,
+      packOptions: generatePackOptions(),
     });
 
-    wrappedResolvers.Query.rootQueryField(
-      { parent: 'parent' },
-      { args: 'args' },
-      { context: 'context' },
-      { info: 'info' },
-    );
+    wrappedResolver({ parent: 'parent' }, { args: 'args' }, { context: 'context' }, { info: 'info' });
 
     const logCalls = logStub.getCalls().map((call) => call.args[0]);
     expect(logCalls).to.deep.equal([
-      'Resolver for type: "Query" field: "rootQueryField"',
+      'Resolver for type: "User" field: "name"',
       'parent: {"parent":"parent"}',
       'args: {"args":"args"}',
-      `context: {"context":"context","pack":${JSON.stringify(
-        generatePackOptions({ dependencies: { graphqlSchema: schema } }),
-      )}}`,
+      `context: {"context":"context"}`,
       'info: {"info":"info"}',
     ]);
   });

--- a/tests/unit/log/wrapper.test.ts
+++ b/tests/unit/log/wrapper.test.ts
@@ -5,6 +5,7 @@ import { ResolverMap } from '../../../src/types';
 import { expect } from 'chai';
 import { stub, SinonStub } from 'sinon';
 import { generatePackOptions } from '../../mocks';
+import { wrapEachField } from '../../../src/resolver-map/wrap-each-field';
 
 describe('log/wrapper', function () {
   let logStub: SinonStub;
@@ -28,7 +29,7 @@ describe('log/wrapper', function () {
       },
     };
 
-    const { resolvers: wrappedResolvers } = pack(resolverMap, [logWrapper], {
+    const { resolvers: wrappedResolvers } = pack(resolverMap, [wrapEachField([logWrapper])], {
       dependencies: { graphqlSchema: schema },
     });
 

--- a/tests/unit/performance/wrapper.test.ts
+++ b/tests/unit/performance/wrapper.test.ts
@@ -3,6 +3,7 @@ import { performanceWrapper } from '../../../src/performance/wrapper';
 import { pack } from '../../../src/resolver-map/pack';
 import { ResolverMap } from '../../../src/types';
 import { expect } from 'chai';
+import { wrapEachField } from '../../../src/resolver-map/wrap-each-field';
 
 describe('performance/wrapper', function () {
   it('provides accesss to spies on resolvers', async function () {
@@ -20,7 +21,7 @@ describe('performance/wrapper', function () {
       },
     };
 
-    const { state, resolvers: wrappedResolvers } = pack(resolverMap, [performanceWrapper], {
+    const { state, resolvers: wrappedResolvers } = pack(resolverMap, [wrapEachField([performanceWrapper])], {
       dependencies: { graphqlSchema },
     });
 

--- a/tests/unit/performance/wrapper.test.ts
+++ b/tests/unit/performance/wrapper.test.ts
@@ -5,7 +5,7 @@ import { generatePackOptions, userObjectType, userObjectNameField } from '../../
 
 describe('performance/wrapper', function () {
   it('provides accesss to spies on resolvers', async function () {
-    const RESOLVER_RUN_TIME_DELAY = 500;
+    const RESOLVER_RUN_TIME_DELAY = 250;
 
     const resolver = async () => {
       return new Promise((resolve) => setTimeout(resolve, RESOLVER_RUN_TIME_DELAY));
@@ -28,10 +28,8 @@ describe('performance/wrapper', function () {
 
     const [timeElapsed] = nameFieldResolverPerformance;
 
-    expect(timeElapsed).to.be.above(
-      RESOLVER_RUN_TIME_DELAY,
-      `the resolver takes at least as long as the timeout, took ${timeElapsed}`,
-    );
+    console.log(`performance/wrapper resolver took ${timeElapsed}`);
+    expect(timeElapsed).to.be.above(RESOLVER_RUN_TIME_DELAY);
 
     expect(timeElapsed).to.be.below(
       RESOLVER_RUN_TIME_DELAY + 100,

--- a/tests/unit/performance/wrapper.test.ts
+++ b/tests/unit/performance/wrapper.test.ts
@@ -1,42 +1,38 @@
-import { buildSchema } from 'graphql';
 import { performanceWrapper } from '../../../src/performance/wrapper';
-import { pack } from '../../../src/resolver-map/pack';
 import { ResolverMap } from '../../../src/types';
 import { expect } from 'chai';
-import { wrapEachField } from '../../../src/resolver-map/wrap-each-field';
+import { generatePackOptions, userObjectType, userObjectNameField } from '../../mocks';
 
 describe('performance/wrapper', function () {
   it('provides accesss to spies on resolvers', async function () {
     const RESOLVER_RUN_TIME_DELAY = 500;
-    const graphqlSchema = buildSchema(`type Query {
-      rootQueryField: String!
-    }`);
 
-    const resolverMap: ResolverMap = {
-      Query: {
-        // eslint-disable-next-line
-        rootQueryField: async () => {
-          return new Promise((resolve) => setTimeout(resolve, RESOLVER_RUN_TIME_DELAY));
-        },
-      },
+    const resolver = async () => {
+      return new Promise((resolve) => setTimeout(resolve, RESOLVER_RUN_TIME_DELAY));
     };
 
-    const { state, resolvers: wrappedResolvers } = pack(resolverMap, [wrapEachField([performanceWrapper])], {
-      dependencies: { graphqlSchema },
+    const packOptions = generatePackOptions();
+    const state = packOptions.state;
+    const wrappedResolver = performanceWrapper(resolver, {
+      resolvers: {} as ResolverMap,
+      type: userObjectType,
+      field: userObjectNameField,
+      packOptions,
     });
 
-    const rootQueryFieldPerformance = state.performance.Query.rootQueryField;
-    expect(rootQueryFieldPerformance).to.deep.equal([]);
+    const nameFieldResolverPerformance = state.performance.User.name;
+    expect(nameFieldResolverPerformance).to.deep.equal([]);
 
-    await wrappedResolvers.Query.rootQueryField({}, {}, {}, {});
-    expect(rootQueryFieldPerformance.length).to.equal(1);
+    await wrappedResolver({}, {}, {}, {});
+    expect(nameFieldResolverPerformance.length).to.equal(1);
 
-    const [timeElapsed] = rootQueryFieldPerformance;
+    const [timeElapsed] = nameFieldResolverPerformance;
 
     expect(timeElapsed).to.be.above(
       RESOLVER_RUN_TIME_DELAY,
       `the resolver takes at least as long as the timeout, took ${timeElapsed}`,
     );
+
     expect(timeElapsed).to.be.below(
       RESOLVER_RUN_TIME_DELAY + 100,
       `Warning: possibly flakey test, depends on how quick the test runs\n\n the resolver runs within 100ms, took ${timeElapsed}`,

--- a/tests/unit/resolver-map/wrap-each.test.ts
+++ b/tests/unit/resolver-map/wrap-each.test.ts
@@ -57,13 +57,15 @@ describe('wrapEach', function () {
     expect(resolverWrapper.callCount).to.equal(2, 'one wrapper for for each resolver');
 
     // firstCall for wrapping Query.field
-    expect(resolverWrapper.firstCall.args[1].path).to.deep.equal(
+    const firstCallPackOptions = resolverWrapper.firstCall.args[1];
+    expect([firstCallPackOptions.type.name, firstCallPackOptions.field.name]).to.deep.equal(
       ['Query', 'field'],
       'first call second arg has correct path',
     );
 
     // secondCall for wrapping SomeType.fieldResolverOnSomeType
-    expect(resolverWrapper.secondCall.args[1].path).to.deep.equal(
+    const secondCallPackOptions = resolverWrapper.secondCall.args[1];
+    expect([secondCallPackOptions.type.name, secondCallPackOptions.field.name]).to.deep.equal(
       ['SomeType', 'fieldResolverOnSomeType'],
       'second call second arg matches',
     );

--- a/tests/unit/resolver-map/wrap-each.test.ts
+++ b/tests/unit/resolver-map/wrap-each.test.ts
@@ -47,7 +47,7 @@ describe('wrapEach', function () {
   });
 
   it('wraps each individual resolver fn in resolver map', function () {
-    resolverMapWrapper = wrapEachField(resolverWrapper);
+    resolverMapWrapper = wrapEachField([resolverWrapper]);
     wrappedResolverMap = resolverMapWrapper(
       clonedResolverMap,
       generatePackOptions({ dependencies: { graphqlSchema } }),

--- a/tests/unit/resolver/wrap-in-map.test.ts
+++ b/tests/unit/resolver/wrap-in-map.test.ts
@@ -1,0 +1,69 @@
+import { expect } from 'chai';
+import { spy, SinonSpy } from 'sinon';
+import { wrapResolverInMap } from '../../../src/resolver/wrap-in-map';
+import { ResolverWrapper } from '../../../src/types';
+import { schema, generatePackOptions } from '../../mocks';
+
+describe('resolver/wrap-in-map', function () {
+  it('it can create a resolver map wrapper using a specified resolver', function () {
+    const resolver = spy();
+    const resolverWrapper: ResolverWrapper = spy((resolver) => (parent: any, args: any, context: any, info: any) =>
+      resolver(parent, args, context, info),
+    );
+
+    const wrappedInResolverMapWrapper = wrapResolverInMap('User', 'name', [resolverWrapper], resolver);
+    const resolverMap = {};
+
+    expect((resolverWrapper as SinonSpy).called).to.equal(false);
+    const wrappedResolverMap = wrappedInResolverMapWrapper(
+      resolverMap,
+      generatePackOptions({ dependencies: { graphqlSchema: schema } }),
+    );
+    expect((resolverWrapper as SinonSpy).called).to.equal(true);
+
+    expect(wrappedResolverMap?.User?.name).is.a('function', 'resolver is installed at specified path');
+    expect(resolver.called).to.equal(false);
+    wrappedResolverMap.User.name({}, {}, {}, {});
+    expect(resolver.called).to.equal(true);
+    expect((resolverWrapper as SinonSpy).called).to.equal(true);
+  });
+
+  it('it can create a resolver map wrapper using existing resolver on map', function () {
+    const nameFieldResolver = spy();
+    const resolverWrapper: ResolverWrapper = spy((resolver) => (parent: any, args: any, context: any, info: any) =>
+      resolver(parent, args, context, info),
+    );
+
+    const wrappedInResolverMapWrapper = wrapResolverInMap('User', 'name', [resolverWrapper]);
+    const resolverMap = {
+      User: {
+        name: nameFieldResolver,
+      },
+    };
+
+    expect((resolverWrapper as SinonSpy).called).to.equal(false);
+    const wrappedResolverMap = wrappedInResolverMapWrapper(
+      resolverMap,
+      generatePackOptions({ dependencies: { graphqlSchema: schema } }),
+    );
+    expect((resolverWrapper as SinonSpy).called).to.equal(true);
+
+    expect(nameFieldResolver.called).to.equal(false);
+    wrappedResolverMap.User.name({}, {}, {}, {});
+    expect(nameFieldResolver.called).to.equal(true);
+    expect((resolverWrapper as SinonSpy).called).to.equal(true);
+  });
+
+  it('throws an error if the specified resolver does not exist, nor on the resolver map', function () {
+    const resolverWrapper: ResolverWrapper = spy();
+    // empty resolver map with no resolver for User.name
+    const resolverMap = {};
+    const wrappedInResolverMapWrapper = wrapResolverInMap('User', 'name', [resolverWrapper]);
+
+    expect(() =>
+      wrappedInResolverMapWrapper(resolverMap, generatePackOptions({ dependencies: { graphqlSchema: schema } })),
+    ).to.throw(
+      'Could not determine resolver to wrap, either pass one into this `wrap`, or have an initial resolver on the resolver map at type: "User", field "name"',
+    );
+  });
+});

--- a/tests/unit/resolver/wrap.test.ts
+++ b/tests/unit/resolver/wrap.test.ts
@@ -1,0 +1,73 @@
+import { expect } from 'chai';
+import { spy, SinonSpy } from 'sinon';
+import { wrapResolver } from '../../../src/resolver/wrap';
+import { generatePackOptions, userObjectType, userObjectNameField } from '../../mocks';
+import { ResolverWrapper, ResolverWrapperOptions, Resolver } from '../../../src/types';
+
+describe('resolver/wrap', function () {
+  let resolverWrapperOptions: ResolverWrapperOptions;
+  const parent = {};
+  const args = {};
+  const info = {};
+  const context = {};
+  let resolver: SinonSpy;
+  let internalWrapperSpy: SinonSpy;
+  let resolverWrapper: SinonSpy;
+
+  beforeEach(() => {
+    resolverWrapperOptions = {
+      packOptions: generatePackOptions(),
+      type: userObjectType,
+      field: userObjectNameField,
+      resolvers: {},
+    };
+
+    resolver = spy();
+    internalWrapperSpy = spy();
+    resolverWrapper = spy((resolver, _options) => {
+      return (parent: any, args: any, context: any, info: any) => {
+        internalWrapperSpy();
+        return resolver(parent, args, context, info);
+      };
+    });
+  });
+
+  it('can wrap a resolver function', function () {
+    const wrappedResolver = wrapResolver(resolver, [resolverWrapper as ResolverWrapper], resolverWrapperOptions);
+    expect(resolverWrapper.called).to.be.true;
+    expect(resolverWrapper.firstCall.args).to.deep.equal([resolver, resolverWrapperOptions]);
+
+    expect(internalWrapperSpy.called).to.be.false;
+    wrappedResolver(parent, args, info, context);
+    expect(internalWrapperSpy.called).to.be.true;
+    expect(resolver.called).to.be.true;
+    expect(resolver.firstCall.args).to.deep.equal([parent, args, info, context]);
+  });
+
+  it('can wrap a resolver function with multiple resolver wrappers', function () {
+    const wrappedResolver = wrapResolver(
+      resolver,
+      // using the same resolverWrapper twice
+      [resolverWrapper as ResolverWrapper, resolverWrapper as ResolverWrapper],
+      resolverWrapperOptions,
+    );
+    expect(resolverWrapper.callCount).to.equal(2);
+    expect(internalWrapperSpy.called).to.be.false;
+    wrappedResolver(parent, args, info, context);
+    expect(internalWrapperSpy.callCount).to.equal(2);
+    expect(resolver.callCount).to.equal(1);
+    expect(resolver.firstCall.args).to.deep.equal([parent, args, info, context]);
+  });
+
+  it('throws an error if a wrapper does not return a function', function () {
+    expect(() =>
+      wrapResolver(
+        resolver,
+        [() => ('resolver wrapper returning a string' as unknown) as Resolver],
+        resolverWrapperOptions,
+      ),
+    ).to.throw(`Wrapper: () => 'resolver wrapper returning a string'
+
+This wrapper did not return a function, got string.`);
+  });
+});

--- a/tests/unit/spy/wrapper.test.ts
+++ b/tests/unit/spy/wrapper.test.ts
@@ -1,34 +1,27 @@
-import { spyWrapper } from '../../../src/spy/wrapper';
-import { pack } from '../../../src/resolver-map/pack';
-import { ResolverMap } from '../../../src/types';
 import { expect } from 'chai';
-import { generatePackOptions } from '../../mocks';
-import { buildSchema } from 'graphql';
-import { wrapEachField } from '../../../src/resolver-map/wrap-each-field';
+import { spyWrapper } from '../../../src/spy/wrapper';
+import { generatePackOptions, userObjectType, userObjectNameField } from '../../mocks';
+import { Resolver } from '../../../src/types';
 
 describe('spy/wrapper', function () {
   it('provides accesss to spies on resolvers', function () {
-    const graphqlSchema = buildSchema(`type Query {
-      rootQueryField: String!
-    }`);
+    const resolverReturnValue = 'resolver return value!';
+    const initialResolver = () => resolverReturnValue;
+    const packOptions = generatePackOptions();
+    const state = packOptions.state;
 
-    const resolverMap: ResolverMap = {
-      Query: {
-        // eslint-disable-next-line
-        rootQueryField: () => {},
-      },
-    };
+    const wrappedResolver = spyWrapper(initialResolver as Resolver, {
+      resolvers: {},
+      type: userObjectType,
+      field: userObjectNameField,
+      packOptions: packOptions,
+    });
 
-    const { state, resolvers: wrappedResolvers } = pack(
-      resolverMap,
-      [wrapEachField([spyWrapper])],
-      generatePackOptions({ dependencies: { graphqlSchema } }),
-    );
+    const resolverSpy = state.spies.User.name;
+    expect(resolverSpy.called).to.equal(false);
 
-    const rootQueryFieldSpy = state.spies.Query.rootQueryField;
-    expect(rootQueryFieldSpy.called).to.equal(false);
-
-    wrappedResolvers.Query.rootQueryField({}, {}, {}, {});
-    expect(rootQueryFieldSpy.called).to.equal(true);
+    wrappedResolver({}, {}, {}, {});
+    expect(resolverSpy.called).to.equal(true);
+    expect(resolverSpy.firstCall.returnValue).to.equal(resolverReturnValue);
   });
 });

--- a/tests/unit/spy/wrapper.test.ts
+++ b/tests/unit/spy/wrapper.test.ts
@@ -4,6 +4,7 @@ import { ResolverMap } from '../../../src/types';
 import { expect } from 'chai';
 import { generatePackOptions } from '../../mocks';
 import { buildSchema } from 'graphql';
+import { wrapEachField } from '../../../src/resolver-map/wrap-each-field';
 
 describe('spy/wrapper', function () {
   it('provides accesss to spies on resolvers', function () {
@@ -20,7 +21,7 @@ describe('spy/wrapper', function () {
 
     const { state, resolvers: wrappedResolvers } = pack(
       resolverMap,
-      [spyWrapper],
+      [wrapEachField([spyWrapper])],
       generatePackOptions({ dependencies: { graphqlSchema } }),
     );
 

--- a/tests/unit/stash-state/wrapper.test.ts
+++ b/tests/unit/stash-state/wrapper.test.ts
@@ -5,6 +5,7 @@ import { expect } from 'chai';
 import * as sinon from 'sinon';
 import { generatePackOptions } from '../../mocks';
 import { buildSchema } from 'graphql';
+import { wrapEachField } from '../../../src/resolver-map/wrap-each-field';
 
 describe('stash-state/wrapper', function () {
   it('saves stashes on a result object', function () {
@@ -22,7 +23,7 @@ describe('stash-state/wrapper', function () {
 
     const { resolvers: wrappedResolvers } = pack(
       resolverMap,
-      [stashStateWrapper],
+      [wrapEachField([stashStateWrapper])],
       generatePackOptions({ dependencies: { graphqlSchema } }),
     );
 


### PR DESCRIPTION
Adds a lower level wrapper for just resolvers. This can be used directly via `resolver/wrap` or more easily with the `resolver/wrap-in-map` which is compatible directly for adding one-off resolvers in a resolver map with resolver wrappers.