### PR TITLE
Add a GraphQL Handler

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "eslint-config-prettier": "^6.10.0",
     "eslint-plugin-prettier": "^3.1.2",
     "graphql": "^14",
-    "graphql-tools": "^5.0.0",
     "miragejs": "^0.1.39",
     "mocha": "^7.1.1",
     "np": "^6.2.3",

--- a/src/graphql/handler.ts
+++ b/src/graphql/handler.ts
@@ -1,0 +1,83 @@
+import { graphql, GraphQLSchema, printSchema, buildSchema } from 'graphql';
+import { pack, defaultPackOptions } from '../resolver-map/pack';
+import { ResolverMap, ResolverMapMiddleware, PackOptions, PackState } from '../types';
+import { addTypeResolversToSchema, addFieldResolverstoSchema } from './utils';
+
+export type QueryHandler = {
+  state: PackState;
+  graphqlSchema: GraphQLSchema;
+  query: (query: string, variables?: Record<string, unknown>) => ReturnType<typeof graphql>;
+};
+
+export type CreateQueryHandlerOptions = {
+  dependencies: PackOptions['dependencies'] & { graphqlSchema: GraphQLSchema | string };
+  middlewares?: ResolverMapMiddleware[];
+  state?: PackOptions['state'];
+};
+
+export function createQueryHandler(resolverMap: ResolverMap = {}, options: CreateQueryHandlerOptions): QueryHandler {
+  let originalSchema = options?.dependencies?.graphqlSchema;
+
+  if (typeof originalSchema === 'string') {
+    try {
+      originalSchema = buildSchema(originalSchema);
+    } catch (error) {
+      throw new Error(
+        'Unable to build a schema from the string passed into the `graphqlSchema` dependency. Failed with error:\n\n' +
+          error.message,
+      );
+    }
+  }
+
+  if (typeof originalSchema !== 'object') {
+    throw new Error(`Expected graphqlSchema to be an object, got "${typeof originalSchema}".
+Please double-check that a graphqlSchema dependency is provided:
+createQueryHandler(initialResolverMap, { dependencies: { graphqlSchema: schema }})
+`);
+  }
+
+  const { middlewares = [] } = options;
+
+  // create a copy of the schema by dumping the passed in schema to a string
+  // and then using buildSchema on the string to rebuild a schema instance
+  const graphqlSchema = buildSchema(printSchema(originalSchema));
+
+  const packOptions = {
+    ...defaultPackOptions,
+
+    dependencies: {
+      ...defaultPackOptions.dependencies,
+      ...options.dependencies,
+      graphqlSchema,
+    },
+    state: options.state ?? defaultPackOptions.state,
+  };
+
+  // pack middlewares against resolverMap
+  const { resolverMap: packedResolverMap, state } = pack(resolverMap, middlewares, packOptions);
+
+  // apply resolverMap against copied graphql schema, attaching to schema:
+  // 1. Field Resolvers { Type: { field: fieldResolver } }
+  // 2. Type Resolvers for Abstract Types (interfaces, unions):
+  //    { Type: { __resolveType: typeResolver }}
+  addFieldResolverstoSchema(packedResolverMap, graphqlSchema);
+  addTypeResolversToSchema(packedResolverMap, graphqlSchema);
+
+  const query: QueryHandler['query'] = async (query, variables = {}) => {
+    if (typeof variables !== 'object') {
+      throw new Error(`Variables must be an object, got ${typeof variables}`);
+    }
+
+    return graphql({
+      schema: graphqlSchema,
+      source: query,
+      variableValues: variables,
+    });
+  };
+
+  return {
+    state,
+    graphqlSchema,
+    query,
+  };
+}

--- a/src/graphql/index.ts
+++ b/src/graphql/index.ts
@@ -1,0 +1,1 @@
+export { createQueryHandler } from './handler';

--- a/src/graphql/utils.ts
+++ b/src/graphql/utils.ts
@@ -1,0 +1,34 @@
+import { ResolverMap } from '../types';
+import { GraphQLSchema, GraphQLInterfaceType, GraphQLUnionType, GraphQLObjectType } from 'graphql';
+
+export function addTypeResolversToSchema(resolverMap: ResolverMap, schema: GraphQLSchema): void {
+  for (const typeName in resolverMap) {
+    const type = schema.getType(typeName);
+
+    //  Note: __resolveType for type resolvers is a convention borrowed from
+    //  graphql-tools resolver maps. This allows a single ResolverMap to be used
+    // for both type resolvers for abstract types (unions & interfaces), as well
+    // as field resolvers
+    const typeResolver = resolverMap[typeName].__resolveType;
+    const hasTypeResolver = Boolean(typeResolver);
+
+    if (hasTypeResolver && (type instanceof GraphQLInterfaceType || type instanceof GraphQLUnionType)) {
+      type.resolveType = typeResolver;
+    }
+  }
+}
+
+export function addFieldResolverstoSchema(resolverMap: ResolverMap, schema: GraphQLSchema): void {
+  for (const typeName in resolverMap) {
+    const type = schema.getType(typeName);
+
+    if (!(type instanceof GraphQLObjectType)) {
+      continue;
+    }
+
+    for (const fieldName in resolverMap[typeName]) {
+      const fieldMap = type.getFields();
+      fieldMap[fieldName].resolve = resolverMap[typeName][fieldName];
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
+export * from './graphql';
 export * from './resolver-map';
 export * from './resolver';

--- a/src/resolver-map/pack.ts
+++ b/src/resolver-map/pack.ts
@@ -3,7 +3,7 @@ import cloneDeep from 'lodash.clonedeep';
 import { wrapEachField } from './wrap-each-field';
 import { embedPackOptionsWrapper } from '../utils';
 
-const defaultPackOptions: PackOptions = { state: {}, dependencies: {} };
+export const defaultPackOptions: PackOptions = { state: {}, dependencies: {} };
 
 export const pack: Packer = (initialResolversMap = {}, middlewares = [], packOptions = defaultPackOptions) => {
   middlewares = [...middlewares, wrapEachField([embedPackOptionsWrapper])];

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,7 +32,7 @@ export type ResolverWrapperOptions = {
 export type ResolverMap<TFieldResolver = Resolver, TTypeResolver = GraphQLTypeResolver<any, any>> = {
   [typeName: string]: {
     [fieldName: string]: TFieldResolver;
-  } & { __resolveType?: TTypeResolver };
+  } & { __resolveType?: TTypeResolver }; // the convention of using __resolveType on a ResolverMap is borrowed from `graphql-tools`
 };
 
 export type PackState = Record<any, any>;

--- a/test/integration/mirage-auto-resolver.test.ts
+++ b/test/integration/mirage-auto-resolver.test.ts
@@ -5,7 +5,7 @@ import { patchModelTypes } from '../../src/mirage/middleware/patch-model-types';
 import { patchUnionsInterfaces } from '../../src/mirage/middleware/patch-auto-unions-interfaces';
 import { server as mirageServer } from './test-helpers/mirage-sample';
 import defaultScenario from './test-helpers/mirage-sample/scenarios/default';
-import { graphqlSchema } from './test-helpers/executable-schema';
+import { graphqlSchema } from './test-helpers/test-schema';
 import { MirageGraphQLMapper } from '../../src/mirage/mapper';
 import { ResolverMap } from '../../src/types';
 import { createQueryHandler } from '../../src/graphql';

--- a/test/integration/mirage-auto-resolver.test.ts
+++ b/test/integration/mirage-auto-resolver.test.ts
@@ -5,12 +5,12 @@ import { patchModelTypes } from '../../src/mirage/middleware/patch-model-types';
 import { patchUnionsInterfaces } from '../../src/mirage/middleware/patch-auto-unions-interfaces';
 import { server as mirageServer } from './test-helpers/mirage-sample';
 import defaultScenario from './test-helpers/mirage-sample/scenarios/default';
-import { buildHandler, graphqlSchema } from './test-helpers/executable-schema';
-import { pack } from '../../src/resolver-map/pack';
+import { graphqlSchema } from './test-helpers/executable-schema';
 import { MirageGraphQLMapper } from '../../src/mirage/mapper';
 import { ResolverMap } from '../../src/types';
+import { createQueryHandler } from '../../src/graphql';
 
-describe('auto resolving from mirage', function () {
+describe('integration/mirage-auto-resolver', function () {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let graphQLHandler: any;
   let resolvers: ResolverMap;
@@ -25,29 +25,23 @@ describe('auto resolving from mirage', function () {
 
     mirageServer.db.loadData(defaultScenario);
     const middlewares = [patchModelTypes, patchUnionsInterfaces];
-    const packed = pack(defaultResolvers, middlewares, {
+    const handler = createQueryHandler(defaultResolvers, {
+      state: {},
+      middlewares,
       dependencies: {
         mapper,
         mirageServer,
         graphqlSchema: graphqlSchema,
       },
     });
-    resolvers = packed.resolverMap;
-    graphQLHandler = buildHandler(resolvers);
+
+    graphQLHandler = handler.query;
   });
 
   this.afterEach(() => {
     mirageServer.db.emptyData();
     (resolvers as unknown) = undefined;
     graphQLHandler = undefined;
-  });
-
-  it('has missing resolvers that are filled by #patchWithAutoResolvers', function () {
-    expect(defaultResolvers.Post).to.equal(undefined);
-    expect(resolvers.Post).to.not.equal(undefined);
-
-    expect(defaultResolvers.Comment).to.equal(undefined);
-    expect(resolvers.Comment).to.not.equal(undefined);
   });
 
   it('can handle a type look up', async function () {

--- a/test/integration/mirage-context-resolvers.test.ts
+++ b/test/integration/mirage-context-resolvers.test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { graphqlSchema } from './test-helpers/executable-schema';
+import { graphqlSchema } from './test-helpers/test-schema';
 import defaultResolvers from './test-helpers/mirage-static-resolvers';
 import { server as mirageServer } from './test-helpers/mirage-sample';
 import defaultScenario from './test-helpers/mirage-sample/scenarios/default';

--- a/test/integration/mirage-context-resolvers.test.ts
+++ b/test/integration/mirage-context-resolvers.test.ts
@@ -1,22 +1,17 @@
 import { expect } from 'chai';
-import { buildHandler, graphqlSchema } from './test-helpers/executable-schema';
+import { graphqlSchema } from './test-helpers/executable-schema';
 import defaultResolvers from './test-helpers/mirage-static-resolvers';
 import { server as mirageServer } from './test-helpers/mirage-sample';
 import defaultScenario from './test-helpers/mirage-sample/scenarios/default';
-import { pack } from '../../src/resolver-map/pack';
-import { ResolverMapMiddleware } from '../../src/types';
+import { createQueryHandler } from '../../src/graphql';
 
-const emptyMiddlewares: ResolverMapMiddleware[] = [];
-
-const { resolverMap } = pack(defaultResolvers, emptyMiddlewares, {
+const { query: graphQLHandler } = createQueryHandler(defaultResolvers, {
   state: {},
   dependencies: {
     mirageServer,
     graphqlSchema,
   },
 });
-
-const graphQLHandler = buildHandler(resolverMap);
 
 describe('it can resolve from basic resolvers', function () {
   beforeEach(() => {

--- a/test/integration/test-helpers/executable-schema.ts
+++ b/test/integration/test-helpers/executable-schema.ts
@@ -1,21 +1,7 @@
-import { buildSchema, graphql } from 'graphql';
-import { addResolversToSchema } from 'graphql-tools';
+import { buildSchema } from 'graphql';
 import { readFileSync } from 'fs';
 import path from 'path';
-import { ResolverMap } from '../../../src/types';
 
 const schemaPath = path.resolve(__dirname, 'schema.graphql');
 export const typeDefs = readFileSync(schemaPath, 'utf-8');
 export const graphqlSchema = buildSchema(typeDefs);
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function buildHandler(resolvers: ResolverMap): any {
-  const graphqlSchema = buildSchema(typeDefs);
-  addResolversToSchema(graphqlSchema, resolvers);
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const graphQLHandler = (query: string, variables: Record<string, unknown> = {}): Promise<any> =>
-    graphql(graphqlSchema, query, resolvers, null, variables);
-
-  return graphQLHandler;
-}

--- a/test/integration/test-helpers/test-schema.ts
+++ b/test/integration/test-helpers/test-schema.ts
@@ -3,5 +3,5 @@ import { readFileSync } from 'fs';
 import path from 'path';
 
 const schemaPath = path.resolve(__dirname, 'schema.graphql');
-export const typeDefs = readFileSync(schemaPath, 'utf-8');
+const typeDefs = readFileSync(schemaPath, 'utf-8');
 export const graphqlSchema = buildSchema(typeDefs);

--- a/test/unit/graphql/handler.test.ts
+++ b/test/unit/graphql/handler.test.ts
@@ -1,0 +1,92 @@
+import { expect } from 'chai';
+import { createQueryHandler, QueryHandler } from '../../../src/graphql/handler';
+import { ResolverMap } from '../../../src/types';
+import { buildSchema } from 'graphql';
+import { wrapEachField } from '../../../src/resolver-map';
+import { spyWrapper } from '../../../src/spy';
+
+describe('graphql/hander', function () {
+  const schemaString = `
+    schema {
+      query: Query
+    }
+
+    type Query {
+      hello: String!
+    }
+  `;
+
+  let handler: QueryHandler;
+  let resolverMap: ResolverMap;
+
+  beforeEach(() => {
+    resolverMap = {
+      Query: {
+        hello: (): string => 'Hello world!',
+      },
+    };
+  });
+
+  it('can execute a graphql query constructed from a schema string', async function () {
+    handler = createQueryHandler(resolverMap, { dependencies: { graphqlSchema: schemaString } });
+    const result = await handler.query(`
+      {
+        hello
+      }
+    `);
+
+    expect(result).to.deep.equal({
+      data: {
+        hello: 'Hello world!',
+      },
+    });
+  });
+
+  it('can execute a graphql query constructed from a schema instance', async function () {
+    const schemaInstance = buildSchema(schemaString);
+    handler = createQueryHandler(resolverMap, { dependencies: { graphqlSchema: schemaInstance } });
+    const result = await handler.query(`
+      {
+        hello
+      }
+    `);
+
+    expect(result).to.deep.equal({
+      data: {
+        hello: 'Hello world!',
+      },
+    });
+  });
+
+  it('throws a helpful error if the schema string cannot be parsed', async function () {
+    expect(
+      () =>
+        (handler = createQueryHandler(resolverMap, { dependencies: { graphqlSchema: 'NOT A VALID GRAPHQL STRING' } })),
+    ).to
+      .throw(`Unable to build a schema from the string passed into the \`graphqlSchema\` dependency. Failed with error:
+
+Syntax Error: Unexpected Name "NOT"`);
+  });
+
+  it('returns maintains the same state object argument', async function () {
+    const initialState = { key: 'value' };
+    const handler = await createQueryHandler(resolverMap, {
+      state: initialState,
+      dependencies: { graphqlSchema: schemaString },
+    });
+
+    expect(handler.state).to.deep.equal(initialState);
+  });
+
+  it('can use ResolverMap middlewares', async function () {
+    // using the wrapEachField middleware with the spyWrapper
+    // produces a state with the spy function accessible at
+    // state.spies.Query.hello
+    const handler = await createQueryHandler(resolverMap, {
+      middlewares: [wrapEachField([spyWrapper])],
+      dependencies: { graphqlSchema: schemaString },
+    });
+
+    expect(handler.state.spies.Query.hello).to.exist;
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,13 +23,6 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/runtime@^7.9.2":
-  version "7.9.2"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.9.2.tgz#d90df0583a3a252f09aaa619665367bae518db06"
-  integrity sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==
-  dependencies:
-    regenerator-runtime "^0.13.4"
-
 "@miragejs/pretender-node-polyfill@^0.1.0":
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/@miragejs/pretender-node-polyfill/-/pretender-node-polyfill-0.1.2.tgz#d26b6b7483fb70cd62189d05c95d2f67153e43f2"
@@ -238,13 +231,6 @@
     semver "^6.3.0"
     tsutils "^3.17.1"
 
-"@wry/equality@^0.1.2":
-  version "0.1.11"
-  resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.1.11.tgz#35cb156e4a96695aa81a9ecc4d03787bc17f1790"
-  integrity sha512-mwEVBDUVODlsQQ5dfuLUS5/Tf7jqUKyhKYHmVi4fPB6bDMOfWvUPJmKgS1Z7Za/sOI3vzWt4+O7yCiL/70MogA==
-  dependencies:
-    tslib "^1.9.3"
-
 acorn-jsx@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.2.0.tgz#4c66069173d6fdd68ed85239fc256226182b2ebe"
@@ -347,45 +333,6 @@ anymatch@~3.1.1:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
-apollo-link-http-common@^0.2.14:
-  version "0.2.16"
-  resolved "https://registry.yarnpkg.com/apollo-link-http-common/-/apollo-link-http-common-0.2.16.tgz#756749dafc732792c8ca0923f9a40564b7c59ecc"
-  integrity sha512-2tIhOIrnaF4UbQHf7kjeQA/EmSorB7+HyJIIrUjJOKBgnXwuexi8aMecRlqTIDWcyVXCeqLhUnztMa6bOH/jTg==
-  dependencies:
-    apollo-link "^1.2.14"
-    ts-invariant "^0.4.0"
-    tslib "^1.9.3"
-
-apollo-link@^1.2.12, apollo-link@^1.2.14:
-  version "1.2.14"
-  resolved "https://registry.yarnpkg.com/apollo-link/-/apollo-link-1.2.14.tgz#3feda4b47f9ebba7f4160bef8b977ba725b684d9"
-  integrity sha512-p67CMEFP7kOG1JZ0ZkYZwRDa369w5PIjtMjvrQd/HnIV8FRsHRqLqK+oAZQnFa1DDdZtOtHTi+aMIW6EatC2jg==
-  dependencies:
-    apollo-utilities "^1.3.0"
-    ts-invariant "^0.4.0"
-    tslib "^1.9.3"
-    zen-observable-ts "^0.8.21"
-
-apollo-upload-client@^13.0.0:
-  version "13.0.0"
-  resolved "https://registry.yarnpkg.com/apollo-upload-client/-/apollo-upload-client-13.0.0.tgz#146d1ddd85d711fcac8ca97a72d3ca6787f2b71b"
-  integrity sha512-lJ9/bk1BH1lD15WhWRha2J3+LrXrPIX5LP5EwiOUHv8PCORp4EUrcujrA3rI5hZeZygrTX8bshcuMdpqpSrvtA==
-  dependencies:
-    "@babel/runtime" "^7.9.2"
-    apollo-link "^1.2.12"
-    apollo-link-http-common "^0.2.14"
-    extract-files "^8.0.0"
-
-apollo-utilities@^1.3.0:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/apollo-utilities/-/apollo-utilities-1.3.3.tgz#f1854715a7be80cd810bc3ac95df085815c0787c"
-  integrity sha512-F14aX2R/fKNYMvhuP2t9GD9fggID7zp5I96MF5QeKYWDWTrkRdHRp4+SVfXUVN+cXOaB/IebfvRtzPf25CM0zw==
-  dependencies:
-    "@wry/equality" "^0.1.2"
-    fast-json-stable-stringify "^2.0.0"
-    ts-invariant "^0.4.0"
-    tslib "^1.10.0"
-
 arg@^4.1.0:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
@@ -429,11 +376,6 @@ async-exit-hook@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/async-exit-hook/-/async-exit-hook-2.0.1.tgz#8bd8b024b0ec9b1c01cccb9af9db29bd717dfaf3"
   integrity sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==
-
-asynckit@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
-  integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -668,13 +610,6 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-combined-stream@^1.0.8:
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
-  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
-  dependencies:
-    delayed-stream "~1.0.0"
-
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -808,16 +743,6 @@ del@^4.1.0:
     p-map "^2.0.0"
     pify "^4.0.1"
     rimraf "^2.6.3"
-
-delayed-stream@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
-  integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
-
-deprecated-decorator@^0.1.6:
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/deprecated-decorator/-/deprecated-decorator-0.1.6.tgz#00966317b7a12fe92f3cc831f7583af329b86c37"
-  integrity sha1-AJZjF7ehL+kvPMgx91g68ym4bDc=
 
 diff@3.5.0:
   version "3.5.0"
@@ -1069,11 +994,6 @@ external-editor@^3.0.3:
     iconv-lite "^0.4.24"
     tmp "^0.0.33"
 
-extract-files@^8.0.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/extract-files/-/extract-files-8.1.0.tgz#46a0690d0fe77411a2e3804852adeaa65cd59288"
-  integrity sha512-PTGtfthZK79WUMk+avLmwx3NGdU8+iVFXC2NMGxKsn0MnihOG2lvumj+AZo8CTwTrwjXDgZ5tztbRlEdRjBonQ==
-
 fake-xml-http-request@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/fake-xml-http-request/-/fake-xml-http-request-2.1.1.tgz#279fdac235840d7a4dff77d98ec44bce9fc690a6"
@@ -1170,15 +1090,6 @@ flatted@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.1.tgz#69e57caa8f0eacbc281d2e2cb458d46fdb449e08"
   integrity sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==
-
-form-data@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.0.tgz#31b7e39c85f1355b7139ee0c647cf0de7f83c682"
-  integrity sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.8"
-    mime-types "^2.1.12"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -1318,20 +1229,6 @@ graceful-fs@^4.1.2:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
-
-graphql-tools@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/graphql-tools/-/graphql-tools-5.0.0.tgz#67281c834a0e29f458adba8018f424816fa627e9"
-  integrity sha512-5zn3vtn//382b7G3Wzz3d5q/sh+f7tVrnxeuhTMTJ7pWJijNqLxH7VEzv8VwXCq19zAzHYEosFHfXiK7qzvk7w==
-  dependencies:
-    apollo-link "^1.2.14"
-    apollo-upload-client "^13.0.0"
-    deprecated-decorator "^0.1.6"
-    form-data "^3.0.0"
-    iterall "^1.3.0"
-    node-fetch "^2.6.0"
-    tslib "^1.11.1"
-    uuid "^7.0.3"
 
 graphql@^14:
   version "14.6.0"
@@ -1728,7 +1625,7 @@ issue-regex@^3.1.0:
   resolved "https://registry.yarnpkg.com/issue-regex/-/issue-regex-3.1.0.tgz#0671f094d6449c5b712fac3c9562aecb727d709e"
   integrity sha512-0RHjbtw9QXeSYnIEY5Yrp2QZrdtz21xBDV9C/GIlY2POmgoS6a7qjkYS5siRKXScnuAj5/SPv1C3YForNCHTJA==
 
-iterall@^1.2.2, iterall@^1.3.0:
+iterall@^1.2.2:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.3.0.tgz#afcb08492e2915cbd8a0884eb93a8c94d0d72fea"
   integrity sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==
@@ -2102,18 +1999,6 @@ merge-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
 
-mime-db@1.44.0:
-  version "1.44.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.44.0.tgz#fa11c5eb0aca1334b4233cb4d52f10c5a6272f92"
-  integrity sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==
-
-mime-types@^2.1.12:
-  version "2.1.27"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.27.tgz#47949f98e279ea53119f5722e0f34e529bec009f"
-  integrity sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==
-  dependencies:
-    mime-db "1.44.0"
-
 mimic-fn@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
@@ -2291,11 +2176,6 @@ node-environment-flags@1.0.6:
   dependencies:
     object.getownpropertydescriptors "^2.0.3"
     semver "^5.7.0"
-
-node-fetch@^2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
-  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
 
 normalize-package-data@^2.5.0:
   version "2.5.0"
@@ -2751,11 +2631,6 @@ redent@^3.0.0:
   dependencies:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
-
-regenerator-runtime@^0.13.4:
-  version "0.13.5"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz#d878a1d094b4306d10b9096484b33ebd55e26697"
-  integrity sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==
 
 regexpp@^2.0.1:
   version "2.0.1"
@@ -3228,13 +3103,6 @@ trim-newlines@^3.0.0:
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.0.tgz#79726304a6a898aa8373427298d54c2ee8b1cb30"
   integrity sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==
 
-ts-invariant@^0.4.0:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.4.4.tgz#97a523518688f93aafad01b0e80eb803eb2abd86"
-  integrity sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==
-  dependencies:
-    tslib "^1.9.3"
-
 ts-node@^8.5.4:
   version "8.9.0"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.9.0.tgz#d7bf7272dcbecd3a2aa18bd0b96c7d2f270c15d4"
@@ -3246,7 +3114,7 @@ ts-node@^8.5.4:
     source-map-support "^0.5.17"
     yn "3.1.1"
 
-tslib@^1.10.0, tslib@^1.11.1, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1.8.1, tslib@^1.9.0:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
   integrity sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==
@@ -3354,11 +3222,6 @@ url-regex@^5.0.0:
   dependencies:
     ip-regex "^4.1.0"
     tlds "^1.203.0"
-
-uuid@^7.0.3:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
-  integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
 
 v8-compile-cache@^2.0.3:
   version "2.1.0"
@@ -3522,16 +3385,3 @@ yn@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
   integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
-
-zen-observable-ts@^0.8.21:
-  version "0.8.21"
-  resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-0.8.21.tgz#85d0031fbbde1eba3cd07d3ba90da241215f421d"
-  integrity sha512-Yj3yXweRc8LdRMrCC8nIc4kkjWecPAUVh0TI0OUrWXx6aX790vLcDlWca6I4vsyCGH3LpWxq0dJRcMOFoVqmeg==
-  dependencies:
-    tslib "^1.9.3"
-    zen-observable "^0.8.0"
-
-zen-observable@^0.8.0:
-  version "0.8.15"
-  resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.15.tgz#96415c512d8e3ffd920afd3889604e30b9eaac15"
-  integrity sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==


### PR DESCRIPTION
Provide an out-of-the-box query execution handler while support Resolver Map Middlewares. The goal is to help get people up and running with a query faster than having to rely on `pack` and wire things up themselves.