### PR TITLE
Rename to graphql-mocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lint": "eslint \"./src/**/*.ts\" \"./test/**/*.ts\"",
     "pretest": "tsc --noEmit && yarn lint",
     "test": "mocha -r ts-node/register \"./test/**/*.test.ts\"",
-    "build": "tsc",
+    "build": "tsc --declaration",
     "clean": "rm -rf lib",
     "copy-package-json": "cp package.json lib",
     "build-publishable": "yarn clean && yarn build && yarn copy-package-json",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-mocks",
-  "version": "0.0.0",
+  "version": "0.2.0",
   "description": "Tools for setting up graphql test resolvers",
   "main": ".index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "graphql-test-resolvers",
+  "name": "graphql-mocks",
   "version": "0.0.0",
   "description": "Tools for setting up graphql test resolvers",
   "main": ".index.js",


### PR DESCRIPTION
`graphql-test-resolvers` was an early name during development and ended up causing more confusion that it helped, so I decided to name it simply `graphql-mocks` as it was available 🤷.